### PR TITLE
Observability Part 1

### DIFF
--- a/infra/modules/installment-api/openapi-v1.json
+++ b/infra/modules/installment-api/openapi-v1.json
@@ -1,0 +1,221 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "InstallmentAdvisor.DataApi | v1",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://localhost:55288/"
+    }
+  ],
+  "paths": {
+    "/customers/{customerId}/usage": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get customer usage",
+        "description": "Get the usage history for the customer per month.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/customers/{customerId}/payments": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get customer payments",
+        "description": "Get the payment history for the customer, including dates and amounts.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/customers/{customerId}/endofyear-estimate": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get end-of-year estimate",
+        "description": "Get the end-of-year estimate for the customer, including usage and payments.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/customers/{customerId}/pricesheet": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get price sheet",
+        "description": "Get the current and historical price sheet for the customer.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/customers/{customerId}/contract": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get customer contract",
+        "description": "Get the contract details for the customer, start and end dates and energy types supplied to the customer.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/customers/{customerId}/installment": {
+      "get": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Get customer installments",
+        "description": "Get the installment history for the customer, including amount, currency, start date, frequency, and status.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InstallmentAdvisor.DataApi"
+        ],
+        "summary": "Save installment",
+        "description": "Save the installment amount for the customer.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "InstallmentRequest": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "frequency": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "InstallmentAdvisor.DataApi"
+    }
+  ]
+}

--- a/src/ChatApi/InstallmentAdvisor.ChatApi.csproj
+++ b/src/ChatApi/InstallmentAdvisor.ChatApi.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.0-preview.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.9.4" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.57.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.59.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.57.0-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.57.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.59.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Orchestration" Version="1.57.0-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Runtime.Core" Version="1.57.0-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Runtime.InProcess" Version="1.57.0-preview" />

--- a/src/CodeWith-Installment-Advisor.sln
+++ b/src/CodeWith-Installment-Advisor.sln
@@ -11,6 +11,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A530B71F-F2C1-4862-B3DA-B9D3D8943BFA}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		QuickApiTest.http = QuickApiTest.http
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstallmentAdvisor.ChatApi", "ChatApi\InstallmentAdvisor.ChatApi.csproj", "{008E77BB-9A0C-85AC-0872-1CF4966D2BE6}"

--- a/src/InstallmentAdvisor.AppHost/Program.cs
+++ b/src/InstallmentAdvisor.AppHost/Program.cs
@@ -1,3 +1,4 @@
+using Aspire.Hosting;
 using InstallmentAdvisor.Settings;
 using Microsoft.Extensions.Configuration;
 
@@ -18,9 +19,13 @@ builder.Configuration.GetSection(CosmosDbSettings.Key).Bind(cosmosDbSettings);
 var entraIdSettings = new EntraIdSettings();
 builder.Configuration.GetSection(EntraIdSettings.Key).Bind(entraIdSettings);
 
+var applicationInsightsSettings = new ApplicationInsightsSettings();
+builder.Configuration.GetSection(ApplicationInsightsSettings.Key).Bind(applicationInsightsSettings);
+
 var agentProvisioner = builder.AddProject<Projects.InstallmentAdvisor_FoundryAgentProvisioner>("agent-provisioner")
     .WithEnvironment(AgentsSettings.Key, agentSettings.ToBase64String())
-    .WithEnvironment(AiFoundrySettings.Key, aiFoundrySettings.ToBase64String());
+    .WithEnvironment(AiFoundrySettings.Key, aiFoundrySettings.ToBase64String())
+    .WithEnvironment("EnvironmentName", builder.Environment.EnvironmentName);
 
 var dataApi = builder.AddProject<Projects.InstallmentAdvisor_DataApi>("data-api");
 
@@ -32,6 +37,8 @@ var chatApi = builder.AddProject<Projects.InstallmentAdvisor_ChatApi>("chat-api"
     .WithEnvironment(EntraIdSettings.Key, entraIdSettings.ToBase64String())
     .WithEnvironment("Frontend:Url", builder.Configuration["Frontend:Url"])
     .WithEnvironment("agentIds", builder.Configuration["agentIds"])
+    .WithEnvironment("APPLICATIONINSIGHTS_CONNECTION_STRING", applicationInsightsSettings.ConnectionString)
+    .WithEnvironment("EnvironmentName", builder.Environment.EnvironmentName)
     .WaitForCompletion(agentProvisioner);
 
 var frontendApp = builder.AddNpmApp("frontend", "../frontend")

--- a/src/InstallmentAdvisor.ServiceDefaults/InstallmentAdvisor.ServiceDefaults.csproj
+++ b/src/InstallmentAdvisor.ServiceDefaults/InstallmentAdvisor.ServiceDefaults.csproj
@@ -9,14 +9,15 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/InstallmentAdvisor.Settings/ApplicationInsightsSettings.cs
+++ b/src/InstallmentAdvisor.Settings/ApplicationInsightsSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace InstallmentAdvisor.Settings;
+
+public class ApplicationInsightsSettings : Base64SerializableSettings<AgentsSettings>
+{
+    public const string Key = "ApplicationInsights";
+
+    public string ConnectionString { get; set; } = "";
+}

--- a/src/InstallmentAdvisor.Settings/ApplicationInsightsSettings.cs
+++ b/src/InstallmentAdvisor.Settings/ApplicationInsightsSettings.cs
@@ -1,6 +1,6 @@
 ﻿namespace InstallmentAdvisor.Settings;
 
-public class ApplicationInsightsSettings : Base64SerializableSettings<AgentsSettings>
+public class ApplicationInsightsSettings
 {
     public const string Key = "ApplicationInsights";
 

--- a/src/QuickApiTest.http
+++ b/src/QuickApiTest.http
@@ -1,0 +1,15 @@
+
+
+POST https://localhost:55018/chat
+Accept: */*
+Content-Type: application/json
+
+{
+  "message":"What is the capital of France?",
+  "debug":true,
+  "stream": false,
+  "userid": "12345",
+  "threadid":""
+  
+
+}


### PR DESCRIPTION
Changes in the Aspire ServiceDefaults to add tracing and meters for Semantic Kernel
We should see more in the traces now, but not all yet - so to be continued

Aspire Dashboard shows the trace (as is AppInsights when you fill in the connectionstring)